### PR TITLE
Kernel PCA update

### DIFF
--- a/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
+++ b/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
@@ -12,4 +12,5 @@ That way, \gls{kernel-pca} can capture nonlinear relationships among data points
 
 By using pairwise similarities to construct a kernel matrix, also referred to as a Gram matrix, \gls{kernel-pca} can perform eigenvalue decomposition.
 This process allows for the extraction of principal components in the feature space, similar to the approach used in regular \gls{pca}.
-However, in \gls{kernel-pca}, the eigenvalue decomposition is performed on the kernel matrix rather than the covariance matrix, allowing for the extraction of nonlinear principal components.
+However, in \gls{kernel-pca}, the eigenvalue decomposition is performed on the kernel matrix rather than the covariance matrix, resulting in the prinpical components.
+These principal components are nonlinear combinations of the original data points, enabling the algorithm to capture complex relationships among data points that are not linearly separable in the original space.

--- a/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
+++ b/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
@@ -8,6 +8,7 @@ Similar to \gls{pca}, as described in Section~\ref{subsec:pca}, the goal of \gls
 Unlike \gls{pca}, \gls{kernel-pca} does not compute the covariance matrix of the data directly, as this is often infeasible for high\\-dimensional datasets.
 Instead, \gls{kernel-pca} leverages the kernel trick to compute the similarities between data points directly in the original space using a kernel function.
 This kernel function implicitly computes the dot product in the higher-dimensional feature space without explicitly mapping the data points into that space.
+That way, \gls{kernel-pca} can capture nonlinear relationships among data points without explicitly transforming them into a higher-dimensional space.
 
 By using pairwise similarities to construct a kernel matrix, also referred to as a Gram matrix, \gls{kernel-pca} can perform eigenvalue decomposition.
 This process allows for the extraction of principal components in the feature space, similar to the approach used in regular \gls{pca}.

--- a/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
+++ b/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
@@ -5,10 +5,10 @@ The core idea behind \gls{kernel-pca} is to map data into a higher-dimensional s
 This mapping enables linear separation of data points in the higher-dimensional space, even if they are not linearly separable in the original space.
 
 Similar to \gls{pca}, as described in Section~\ref{subsec:pca}, the goal of \gls{kernel-pca} is to extract the principal components of the data.
-Unlike \gls{pca}, \gls{kernel-pca} does not compute the covariance matrix of the data directly, as it often is infeasible to compute for high-dimensional datasets.
-\gls{kernel-pca} instead leverages the kernel trick to computate the similarities between data points directly in the original space using a kernel function
+Unlike \gls{pca}, \gls{kernel-pca} does not compute the covariance matrix of the data directly, as this is often infeasible for high-dimensional datasets.
+Instead, \gls{kernel-pca} leverages the kernel trick to compute the similarities between data points directly in the original space using a kernel function.
 This kernel function implicitly computes the dot product in the higher-dimensional feature space without explicitly mapping the data points into that space.
-By constructing a kernel matrix, also known as the Gram matrix, using these pairwise similarities, \gls{kernel-pca} can perform eigenvalue decomposition to obtain the principal components in the feature space, similar to regular \gls{pca} as described in Section~\ref{subsec:pca}.
+
 By using pairwise similarities to construct a kernel matrix, also referred to as a Gram matrix, \gls{kernel-pca} can perform eigenvalue decomposition.
 This process allows for the extraction of principal components in the feature space, similar to the approach used in regular \gls{pca} as described in Section~\ref{subsec:pca}.
 However, in \gls{kernel-pca}, the eigenvalue decomposition is performed on the kernel matrix rather than the covariance matrix, allowing for the extraction of nonlinear principal components.

--- a/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
+++ b/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
@@ -5,7 +5,7 @@ The core idea behind \gls{kernel-pca} is to map data into a higher-dimensional s
 This mapping enables linear separation of data points in the higher-dimensional space, even if they are not linearly separable in the original space.
 
 Similar to \gls{pca}, as described in Section~\ref{subsec:pca}, the goal of \gls{kernel-pca} is to extract the principal components of the data.
-Unlike \gls{pca}, \gls{kernel-pca} does not compute the covariance matrix of the data directly, as this is often infeasible for high-dimensional datasets.
+Unlike \gls{pca}, \gls{kernel-pca} does not compute the covariance matrix of the data directly, as this is often infeasible for high\\-dimensional datasets.
 Instead, \gls{kernel-pca} leverages the kernel trick to compute the similarities between data points directly in the original space using a kernel function.
 This kernel function implicitly computes the dot product in the higher-dimensional feature space without explicitly mapping the data points into that space.
 

--- a/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
+++ b/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
@@ -10,5 +10,5 @@ Instead, \gls{kernel-pca} leverages the kernel trick to compute the similarities
 This kernel function implicitly computes the dot product in the higher-dimensional feature space without explicitly mapping the data points into that space.
 
 By using pairwise similarities to construct a kernel matrix, also referred to as a Gram matrix, \gls{kernel-pca} can perform eigenvalue decomposition.
-This process allows for the extraction of principal components in the feature space, similar to the approach used in regular \gls{pca} as described in Section~\ref{subsec:pca}.
+This process allows for the extraction of principal components in the feature space, similar to the approach used in regular \gls{pca}.
 However, in \gls{kernel-pca}, the eigenvalue decomposition is performed on the kernel matrix rather than the covariance matrix, allowing for the extraction of nonlinear principal components.

--- a/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
+++ b/report_thesis/src/sections/background/preprocessing/kernel_pca.tex
@@ -5,8 +5,10 @@ The core idea behind \gls{kernel-pca} is to map data into a higher-dimensional s
 This mapping enables linear separation of data points in the higher-dimensional space, even if they are not linearly separable in the original space.
 
 Similar to \gls{pca}, as described in Section~\ref{subsec:pca}, the goal of \gls{kernel-pca} is to extract the principal components of the data.
-However, unlike \gls{pca}, \gls{kernel-pca} does not compute the covariance matrix of the data directly, as it often is infeasible to compute for high-dimensional datasets.
-\gls{kernel-pca} instead leverages the kernel trick to computate the similarities between data points directly in the original space using a kernel function $k(\mathbf{x}_i, \mathbf{x}_j)$.
-This kernel function implicitly computes the dot product $\Phi(\mathbf{x}_i)^\top \Phi(\mathbf{x}_j)$ in the higher-dimensional feature space without explicitly performing the mapping.
-By constructing a kernel matrix $\mathbf{K}$ using these pairwise similarities, \gls{kernel-pca} can perform eigenvalue decomposition to obtain the principal components in the feature space, similar to regular \gls{pca} as described in Section~\ref{subsec:pca}.
-However, in \gls{kernel-pca}, the eigenvalue decomposition is performed on the kernel matrix $\mathbf{K}$ rather than the covariance matrix $\mathbf{C}$.
+Unlike \gls{pca}, \gls{kernel-pca} does not compute the covariance matrix of the data directly, as it often is infeasible to compute for high-dimensional datasets.
+\gls{kernel-pca} instead leverages the kernel trick to computate the similarities between data points directly in the original space using a kernel function
+This kernel function implicitly computes the dot product in the higher-dimensional feature space without explicitly mapping the data points into that space.
+By constructing a kernel matrix, also known as the Gram matrix, using these pairwise similarities, \gls{kernel-pca} can perform eigenvalue decomposition to obtain the principal components in the feature space, similar to regular \gls{pca} as described in Section~\ref{subsec:pca}.
+By using pairwise similarities to construct a kernel matrix, also referred to as a Gram matrix, \gls{kernel-pca} can perform eigenvalue decomposition.
+This process allows for the extraction of principal components in the feature space, similar to the approach used in regular \gls{pca} as described in Section~\ref{subsec:pca}.
+However, in \gls{kernel-pca}, the eigenvalue decomposition is performed on the kernel matrix rather than the covariance matrix, allowing for the extraction of nonlinear principal components.


### PR DESCRIPTION
Removed the unnecessary mathematical notations as they did not match the source and weren't really used.
Also rephrased some things and included a reference to the "Gram matrix" term for clarification.